### PR TITLE
generate newest valid report version per site, fall back to older

### DIFF
--- a/src/py/dsf-report-parser.py
+++ b/src/py/dsf-report-parser.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 import yaml
 from pathlib import Path
-from site_report import SiteReport
+from site_report import SiteReport, generate_newest_report
 
 DEFAULT_TIMEOUT = 30
 
@@ -101,38 +101,27 @@ if __name__ == "__main__":
     site_identifiers = get_site_identifiers(dsf_base_url, cert_file, key_file)
     reports = get_reports("config/report-queries")
 
-    for report_template in reports:
-        version = report_template['version']
-        logging.info(f'############# Getting reports in report version: -- {version} -- #############')
+    for site_identifier in site_identifiers:
+        if len(activated_identifiers) > 0 and site_identifier not in activated_identifiers:
+            continue
 
-        for site_identifier in site_identifiers:
-            if len(activated_identifiers) > 0 and site_identifier not in activated_identifiers:
-                continue
+        if site_identifier not in site_mapping:
+            logging.info("No mapping for site - falling back to ident")
+            site_mapping[site_identifier] = site_identifier
 
-            logging.info(f'##### Report for site: {site_identifier}')
+        site_name = site_mapping[site_identifier]
 
-            if site_identifier not in site_mapping:
-                logging.info("No mapping for site - falling back to ident")
-                site_mapping[site_identifier] = site_identifier
+        dsf_report_url = (
+            f'{dsf_base_url}/Bundle'
+            f'?identifier=http://medizininformatik-initiative.de/sid/cds-report-identifier'
+            f'|{site_identifier}&_format=json&_sort=-_lastUpdated'
+        )
+        resp = requests.get(dsf_report_url, cert=(cert_file, key_file), timeout=DEFAULT_TIMEOUT)
 
-            site_name = site_mapping[site_identifier]
-            logging.info(f'Converting report for site {site_name}')
+        report = generate_newest_report(reports, resp.json(), site_identifier, site_name, mii_relevant_resources)
 
-            dsf_report_url = (
-                f'{dsf_base_url}/Bundle'
-                f'?identifier=http://medizininformatik-initiative.de/sid/cds-report-identifier'
-                f'|{site_identifier}&_format=json&_sort=-_lastUpdated'
-            )
-            resp = requests.get(dsf_report_url, cert=(cert_file, key_file), timeout=DEFAULT_TIMEOUT)
-
-            report = SiteReport(report_template, site_identifier, site_name, mii_relevant_resources)
-
-            if not report.generate(resp.json()):
-                continue
-
-            if not report.validate():
-                logging.error(f'Report for site {site_name} did not validate => not saving to file')
-                continue
-
-            logging.info(f'SUCCESS: Converted report for site {site_name}')
+        if report:
+            logging.info(f'SUCCESS: Converted report for site {site_name} using version {report.version}')
             report.save()
+        else:
+            logging.error(f'No report version succeeded for site {site_name}')

--- a/src/py/dsf-report-parser.py
+++ b/src/py/dsf-report-parser.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 import yaml
 from pathlib import Path
-from site_report import SiteReport, generate_newest_report
+from site_report import generate_newest_report
 
 DEFAULT_TIMEOUT = 30
 

--- a/src/py/site_report.py
+++ b/src/py/site_report.py
@@ -193,6 +193,18 @@ class SiteReport:
 
     def save(self):
         """Write the generated report to a JSON file in the reports directory."""
-        filename = f'reports/mii-report-site-version{self.version}-{self.site_name}_{self._report["datetime"]}.json'
+        filename = f'reports/mii-report-site-{self.site_name}_{self._report["datetime"]}.json'
         with open(filename, "w+") as fp:
             json.dump(self._report, fp)
+
+
+def generate_newest_report(templates, dsf_result, site_identifier, site_name, mii_relevant_resources):
+    """Try templates newest-first, return the first SiteReport that generates and validates, or None."""
+    sorted_templates = sorted(templates, key=lambda r: tuple(int(x) for x in r['version'].split('.')), reverse=True)
+    for template in sorted_templates:
+        report = SiteReport(template, site_identifier, site_name, mii_relevant_resources)
+        if not report.generate(dsf_result):
+            break
+        if report.validate():
+            return report
+    return None

--- a/src/tests/test_site_report.py
+++ b/src/tests/test_site_report.py
@@ -7,7 +7,7 @@ import pytest
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, os.path.join(REPO_ROOT, "src", "py"))
 
-from site_report import SiteReport  # noqa: E402
+from site_report import SiteReport, generate_newest_report  # noqa: E402
 
 TEST_DATA = os.path.join(REPO_ROOT, "src", "resources", "test-data")
 CONFIG_DIR = os.path.join(REPO_ROOT, "config", "report-queries")
@@ -293,34 +293,30 @@ class TestSave:
         report.save()
 
         saved = list((tmp_path / "reports").glob("*.json"))
-        assert "2.0.1" in saved[0].name
         assert "TestSite" in saved[0].name
 
 
 # ---------------------------------------------------------------------------
-# End-to-end — one input file per report version, full pipeline
+# Fallback — newest version tried first, falls back when it fails
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("version", ["2.0.1", "2.1.0"])
-def test_full_pipeline_for_version(version):
-    input_path = os.path.join(REPO_ROOT, "src", "resources", "test-data", f"dsf-search-result-v{version}.json")
+# (input_version, expected_version, site_name)
+# v2.1.0 input satisfies both versions; v2.0.1 input is missing v2.1.0 queries
+# so the v2.0.1 case exercises the fallback path.
+@pytest.mark.parametrize("input_version,expected_version,site_name", [
+    ("2.1.0", "2.1.0", "SiteNewest"),
+    ("2.0.1", "2.0.1", "SiteFallback"),
+])
+def test_generate_newest_report_picks_correct_version(input_version, expected_version, site_name):
+    input_path = os.path.join(REPO_ROOT, "src", "resources", "test-data", f"dsf-search-result-v{input_version}.json")
     with open(input_path) as f:
         dsf_result = json.load(f)
 
-    template = load_template(version)
-    report = SiteReport(template, "test-site.de", "TestSite", MII_RELEVANT_RESOURCES)
+    templates = [load_template("2.0.1"), load_template("2.1.0")]
+    report = generate_newest_report(templates, dsf_result, "test-site.de", site_name, MII_RELEVANT_RESOURCES)
 
-    assert report.generate(dsf_result) is True
-    assert report.validate() is True
+    assert report is not None
+    assert report.version == expected_version
+    assert report._report["siteName"] == site_name
 
     report.save()
-
-    reports_dir = os.path.join(REPO_ROOT, "reports")
-    saved = [f for f in os.listdir(reports_dir) if f"version{version}" in f and "TestSite" in f]
-    assert len(saved) == 1
-    with open(os.path.join(reports_dir, saved[0])) as f:
-        output = json.load(f)
-    assert output["siteName"] == "TestSite"
-    assert output["version"] == version
-    assert output["datetime"] != ""
-    assert len(output["statusQueries"]) > 0


### PR DESCRIPTION
For each site, try report templates newest-first and save only the first that generates and validates. Extracts generate_newest_report() into site_report.py for testability. Removes version from output filename.